### PR TITLE
v0.0.8 修复：公寓侧边栏高亮与返回报错问题

### DIFF
--- a/smalllife-project/Assets/Scenes/ApartmentPage.unity
+++ b/smalllife-project/Assets/Scenes/ApartmentPage.unity
@@ -270,15 +270,15 @@ RectTransform:
   m_GameObject: {fileID: 168079721}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.598558, y: 0.598558, z: 0.598558}
+  m_LocalScale: {x: 0.8, y: 0.8, z: 0.8}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 263296994}
-  m_RootOrder: 8
+  m_Father: {fileID: 274295670}
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -113.726074, y: -120.90881}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &188639352
@@ -713,8 +713,6 @@ RectTransform:
   - {fileID: 1820826944}
   - {fileID: 268641878}
   - {fileID: 1076915919}
-  - {fileID: 1032249674}
-  - {fileID: 168079722}
   - {fileID: 1798280142}
   - {fileID: 1382410678}
   - {fileID: 607379774}
@@ -865,6 +863,8 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1376141220}
+  - {fileID: 1032249674}
+  - {fileID: 168079722}
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1329,6 +1329,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1032249674}
     m_Modifications:
+    - target: {fileID: 339938907197481992, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 339938908150968183, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_Name
       value: PlacementArea1 (5)
@@ -1339,23 +1343,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 339938908150968184, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_LocalScale.x
-      value: 1.55
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 339938908150968184, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_LocalScale.y
-      value: 1.55
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 339938908150968184, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_LocalScale.z
-      value: 1.55
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 339938908150968184, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 8.6
+      value: 10.62
       objectReference: {fileID: 0}
     - target: {fileID: 339938908150968184, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -3.94
+      value: -4.77
       objectReference: {fileID: 0}
     - target: {fileID: 339938908150968184, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_LocalPosition.z
@@ -1391,7 +1395,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 339938908150968185, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: zoneId
-      value: 3
+      value: 6
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
@@ -2526,6 +2530,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1032249674}
     m_Modifications:
+    - target: {fileID: 339938907197481992, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 339938908150968183, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_Name
       value: PlacementArea1 (1)
@@ -2535,12 +2543,24 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 339938908150968184, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 339938908150968184, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 339938908150968184, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 339938908150968184, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -2.87
+      value: -3.54
       objectReference: {fileID: 0}
     - target: {fileID: 339938908150968184, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 5.03
+      value: 6.43
       objectReference: {fileID: 0}
     - target: {fileID: 339938908150968184, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_LocalPosition.z
@@ -2687,6 +2707,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1032249674}
     m_Modifications:
+    - target: {fileID: 339938907197481992, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 339938908150968183, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_Name
       value: PlacementArea1 (2)
@@ -2697,23 +2721,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 339938908150968184, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_LocalScale.x
-      value: 1.55
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 339938908150968184, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_LocalScale.y
-      value: 1.55
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 339938908150968184, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_LocalScale.z
-      value: 1.55
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 339938908150968184, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -1.44
+      value: -1.62
       objectReference: {fileID: 0}
     - target: {fileID: 339938908150968184, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.55
+      value: 4.49
       objectReference: {fileID: 0}
     - target: {fileID: 339938908150968184, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_LocalPosition.z
@@ -3009,8 +3033,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1032249673}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -910.706, y: -569.22864, z: 0}
-  m_LocalScale: {x: 0.598558, y: 0.598558, z: 0.598558}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.8, y: 0.8, z: 0.8}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1205708408}
@@ -3019,8 +3043,8 @@ Transform:
   - {fileID: 1329280680}
   - {fileID: 1651896493}
   - {fileID: 377740900}
-  m_Father: {fileID: 263296994}
-  m_RootOrder: 7
+  m_Father: {fileID: 274295670}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1070541601
 GameObject:
@@ -3982,6 +4006,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1032249674}
     m_Modifications:
+    - target: {fileID: 339938907197481992, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 339938908150968183, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_Name
       value: PlacementArea1 (3)
@@ -3992,23 +4020,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 339938908150968184, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_LocalScale.x
-      value: 1.55
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 339938908150968184, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_LocalScale.y
-      value: 1.55
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 339938908150968184, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_LocalScale.z
-      value: 1.55
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 339938908150968184, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -7.81
+      value: -9.44
       objectReference: {fileID: 0}
     - target: {fileID: 339938908150968184, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -2.69
+      value: -3.42
       objectReference: {fileID: 0}
     - target: {fileID: 339938908150968184, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_LocalPosition.z
@@ -4044,7 +4072,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 339938908150968185, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: zoneId
-      value: 3
+      value: 4
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
@@ -5133,8 +5161,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -973, y: -559.5647}
-  m_SizeDelta: {x: 334.396, y: 1277.1}
+  m_AnchoredPosition: {x: -953.1168, y: -559.5647}
+  m_SizeDelta: {x: 374.1623, y: 1277.1}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1600135161
 MonoBehaviour:
@@ -5298,6 +5326,14 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1032249674}
     m_Modifications:
+    - target: {fileID: 339938907197481992, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 339938907533659358, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 339938908150968183, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_Name
       value: PlacementArea1 (4)
@@ -5308,23 +5344,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 339938908150968184, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_LocalScale.x
-      value: 1.55
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 339938908150968184, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_LocalScale.y
-      value: 1.55
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 339938908150968184, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_LocalScale.z
-      value: 1.55
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 339938908150968184, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -5.62
+      value: -7.27
       objectReference: {fileID: 0}
     - target: {fileID: 339938908150968184, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -5.23
+      value: -6.46
       objectReference: {fileID: 0}
     - target: {fileID: 339938908150968184, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_LocalPosition.z
@@ -5360,7 +5396,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 339938908150968185, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: zoneId
-      value: 3
+      value: 5
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
@@ -5905,7 +5941,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 263296994}
-  m_RootOrder: 9
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -6744,8 +6780,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 941.2224, y: -559.5647}
-  m_SizeDelta: {x: 334.396, y: 1277.1}
+  m_AnchoredPosition: {x: 939.4148, y: -559.5647}
+  m_SizeDelta: {x: 338.0112, y: 1277.1}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1991918686
 MonoBehaviour:
@@ -6931,6 +6967,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1032249674}
     m_Modifications:
+    - target: {fileID: 339938907197481992, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 339938907533659358, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_IsActive
       value: 0
@@ -6945,23 +6985,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 339938908150968184, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_LocalScale.x
-      value: 1.55
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 339938908150968184, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_LocalScale.y
-      value: 1.55
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 339938908150968184, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_LocalScale.z
-      value: 1.55
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 339938908150968184, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 2.83
+      value: 3.43
       objectReference: {fileID: 0}
     - target: {fileID: 339938908150968184, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.07
+      value: 1.62
       objectReference: {fileID: 0}
     - target: {fileID: 339938908150968184, guid: a67f5f3eee09e454c931524e67d3ef1c, type: 3}
       propertyPath: m_LocalPosition.z

--- a/smalllife-project/Assets/Script/SaveSystem/GameData.cs
+++ b/smalllife-project/Assets/Script/SaveSystem/GameData.cs
@@ -59,6 +59,10 @@ public class GameData
     private List<string> serializedViewedDialogIDs = new();
     // 公寓里的已放置物品
     public List<ApartmentController.PlacedItemData> apartmentPlacedItems = new List<ApartmentController.PlacedItemData>();
+    // 已在 sidebar 显示过的 goalID
+    public HashSet<int> appearedSidebarGoals = new HashSet<int>();
+    // ✅ 记录 sidebar 中已出现过的 goalID
+    public List<int> apartmentSidebarAppearedGoals = new List<int>();
 
     // ========== 序列化函数 ==========保存前调用（将 Dictionary 转为 List）
 

--- a/smalllife-project/Assets/Script/UI/PlacedItem.cs
+++ b/smalllife-project/Assets/Script/UI/PlacedItem.cs
@@ -13,6 +13,7 @@ public class PlacedItem : MonoBehaviour
     [Header("可选")]
     public Animator animator;         // 可选动画控制
 
+
     /// <summary>初始化（生成时调用）</summary>
     public void Init(int id, string savedId = null)
     {
@@ -41,19 +42,6 @@ public class PlacedItem : MonoBehaviour
         // 对齐位置
         transform.position = currentArea.GetSnapPosition();
         Debug.Log($"[PlacedItem] 绑定到区域 zoneId={area.zoneId}, goalID={goalID}");
-        // ---- 可选：自动更新存档 ----
-        var controller = ApartmentController.Instance;
-        if (controller != null)
-        {
-            var data = controller.placedItems.Find(d => d.id == persistId);
-            if (data != null)
-            {
-                data.zoneId = area.zoneId;
-                data.position = area.GetSnapPosition();
-                SaveSystem.GameData.apartmentPlacedItems = controller.placedItems;
-                SaveSystem.SaveGame();
-            }
-        }
     }
 
     /// <summary>释放当前绑定的放置区域</summary>


### PR DESCRIPTION
修复：公寓侧边栏高亮与返回报错问题
- 修复红点/高亮误触发：`apartmentSidebarAppearedGoals` 仅在首次加入时记录，不再在每次加载时重复。
- 同步 GameData 与侧边栏目标状态，避免错误高亮。
- 修复从 DiaryStickerPage 返回 ApartmentPage 时的报错。